### PR TITLE
Make with_ methods return a more intuitive Future

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: rust
 sudo: required
 
 rust:
-  - 1.23.0
+  - 1.26.0
   - stable
   - beta
   - nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - `Mutex::with`, `RwLock::with_read`, and `RwLock::with_write` now require
   their Futures to be `Send`.  They also can return errors.
   ([#7](https://github.com/asomers/futures-locks/pull/7))
+- Methods enabled with the tokio feature now return a Future type equivalent
+  to the one returned by the provided closure.
+  ([#6](https://github.com/asomers/futures-locks/pull/6))
 
 ### Fixed
 - `Mutex::with`, `RwLock::with_read`, and `RwLock::with_write` now work with

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ standard library.  But instead of blocking until ready, they return Futures
 which will become ready when the lock is acquired.  See the doc comments for
 individual examples.
 
-`futures-locks` requires Rust 1.23.0 or higher.
+`futures-locks` requires Rust 1.26.0 or higher.
 
 # License
 

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -165,16 +165,15 @@ fn with_err() {
     let mtx = Mutex::<i32>::new(-5);
     let mut rt = current_thread::Runtime::new().unwrap();
     let r = rt.block_on(lazy(|| {
-        let fut = mtx.with(|guard| {
+        mtx.with(|guard| {
             if *guard > 0 {
                 Ok(*guard)
             } else {
                 Err("Whoops!")
             }
-        }).unwrap();
-        fut.map(|r| assert_eq!(r, Err("Whoops!")))
+        }).unwrap()
     }));
-    assert!(r.is_ok());
+    assert_eq!(r, Err("Whoops!"));
 }
 
 #[cfg(feature = "tokio")]
@@ -183,12 +182,11 @@ fn with_ok() {
     let mtx = Mutex::<i32>::new(5);
     let mut rt = current_thread::Runtime::new().unwrap();
     let r = rt.block_on(lazy(move || {
-        let fut = mtx.with(|guard| {
+        mtx.with(|guard| {
             Ok(*guard) as Result<i32, ()>
-        }).unwrap();
-        fut.map(|r| assert_eq!(r, Ok(5)))
+        }).unwrap()
     }));
-    assert!(r.is_ok());
+    assert_eq!(r, Ok(5));
 }
 
 // Mutex::with should work with multithreaded Runtimes as well as
@@ -200,12 +198,11 @@ fn with_threadpool() {
     let mtx = Mutex::<i32>::new(5);
     let mut rt = runtime::Runtime::new().unwrap();
     let r = rt.block_on(lazy(move || {
-        let fut = mtx.with(|guard| {
+        mtx.with(|guard| {
             Ok(*guard) as Result<i32, ()>
-        }).unwrap();
-        fut.map(|r| assert_eq!(r, Ok(5)))
+        }).unwrap()
     }));
-    assert!(r.is_ok());
+    assert_eq!(r, Ok(5));
 }
 
 #[cfg(feature = "tokio")]
@@ -215,10 +212,9 @@ fn with_local_ok() {
     let mtx = Mutex::<Rc<i32>>::new(Rc::new(5));
     let mut rt = current_thread::Runtime::new().unwrap();
     let r = rt.block_on(lazy(move || {
-        let fut = mtx.with_local(|guard| {
+        mtx.with_local(|guard| {
             Ok(**guard) as Result<i32, ()>
-        });
-        fut.map(|r| assert_eq!(r, Ok(5)))
+        })
     }));
-    assert!(r.is_ok());
+    assert_eq!(r, Ok(5));
 }


### PR DESCRIPTION
Currently, if I provide a `Future<Foo, Bar>` fo `Mutex::with`, what I get in return is a `Future<Result<Foo, Bar>, CanceledError>` which is really not intuitive. Given we handle internally the transmitter, we're sure it won't be dropped, hence the CanceledError can't happen. Just get rid of it to make the return type a `Future<Foo, Bar>` as one would expect