### PR TITLE
Mutex::with and Mutex::with_local should return the same types

### DIFF
--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -214,7 +214,7 @@ fn with_local_ok() {
     let r = rt.block_on(lazy(move || {
         mtx.with_local(|guard| {
             Ok(**guard) as Result<i32, ()>
-        })
+        }).unwrap()
     }));
     assert_eq!(r, Ok(5));
 }

--- a/tests/rwlock.rs
+++ b/tests/rwlock.rs
@@ -366,7 +366,7 @@ fn with_read_local_ok() {
     let r = rt.block_on(lazy(move || {
         rwlock.with_read_local(|guard| {
             Ok(**guard) as Result<i32, ()>
-        })
+        }).unwrap()
     }));
     assert_eq!(r, Ok(5));
 }
@@ -436,7 +436,7 @@ fn with_write_local_ok() {
         rwlock.with_write_local(|mut guard| {
             *Rc::get_mut(&mut *guard).unwrap() += 1;
             Ok(()) as Result<(), ()>
-        })
+        }).unwrap()
     }));
     assert!(r.is_ok());
     assert_eq!(*rwlock.try_unwrap().unwrap(), 6);


### PR DESCRIPTION
Make Mutex::with_local return SpawnError instead of unwrapping it, just
like Mutex::with does.  Make the same change to
RwLock::{with_read_local, with_write_local}

Fixes #8
Reported-by:	Marc-Antoine Perennou