### PR TITLE
Raise tokio dev dependency to 0.1.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tokio-executor = { version = "0.1.5", optional = true }
 # features, dependencies, dev-dependencies, and build-dependencies all share
 # the same namespace. To avoid a clash with the `tokio` feature, rename the
 # `tokio` dev-dependency. See https://github.com/rust-lang/cargo/issues/4866.
-tokio_ = { version = "0.1.4", package = "tokio" }
+tokio_ = { version = "0.1.8", package = "tokio" }
 
 [[test]]
 name = "functional"


### PR DESCRIPTION
This was an oversight from PR #10.  The tests don't compile with tokio
less than 0.1.7, and they don't pass with tokio less than 0.1.8.  CI
didn't reveal the problem because new repos use the latest crates by
default.