### PR TITLE
Implement WeakMutex by using the sync::Weak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased] - ReleaseDate
+### Added
+- Added `MutexWeak` by using the `sync::Weak`
+  ([#17](https://github.com/asomers/futures-locks/pull/17)) 
+
 ## [0.3.2] - 2019-01-30
 ### Changed
 - Better documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased] - ReleaseDate
 ### Added
-- Added `MutexWeak` by using the `sync::Weak`
+- Added `MutexWeak`
   ([#17](https://github.com/asomers/futures-locks/pull/17)) 
 
 ## [0.3.2] - 2019-01-30

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ extern crate futures;
 mod mutex;
 mod rwlock;
 
-pub use mutex::{Mutex, MutexFut, MutexGuard, WeakMutex};
+pub use mutex::{Mutex, MutexFut, MutexGuard, MutexWeak};
 pub use rwlock::{RwLock, RwLockReadFut, RwLockWriteFut,
                  RwLockReadGuard, RwLockWriteGuard};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ extern crate futures;
 mod mutex;
 mod rwlock;
 
-pub use mutex::{Mutex, MutexFut, MutexGuard};
+pub use mutex::{Mutex, MutexFut, MutexGuard, WeakMutex};
 pub use rwlock::{RwLock, RwLockReadFut, RwLockWriteFut,
                  RwLockReadGuard, RwLockWriteGuard};
 

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -154,6 +154,12 @@ impl<T: ?Sized> WeakMutex<T> {
     }
 }
 
+impl<T: ?Sized> Clone for WeakMutex<T> {
+    fn clone(&self) -> WeakMutex<T> {
+        WeakMutex{inner: self.inner.clone()}
+    }
+}
+
 /// A Futures-aware Mutex.
 ///
 /// `std::sync::Mutex` cannot be used in an asynchronous environment like Tokio,

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -140,6 +140,20 @@ struct Inner<T: ?Sized> {
     data: UnsafeCell<T>,
 }
 
+/// `MutexWeak` is non-owning reference to a mutex like [`Weak`] for [`Arc`].
+/// 
+/// # Example
+/// ```
+/// # use futures_locks::{Mutex,MutexGuard};
+/// # fn main() {
+/// let mutex = Mutex::<u32>::new(0);
+/// let mutex_weak = Mutex::downgrade(&mutex);
+/// let mutex_new = mutex_weak.upgrade().unwrap();
+/// # }
+/// ```
+///
+/// [`Weak`]: https://doc.rust-lang.org/std/sync/struct.Weak.html
+/// [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
 #[derive(Debug)]
 pub struct MutexWeak<T: ?Sized> {
     inner: sync::Weak<Inner<T>>,

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -163,9 +163,7 @@ pub struct MutexWeak<T: ?Sized> {
 
 impl<T: ?Sized> MutexWeak<T> {
     /// Tries to upgrade the `MutexWeak` to `Mutex`. If the `Mutex` was dropped 
-    /// then the function return [`None`].
-    ///
-    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html
+    /// then the function return `None`.
     pub fn upgrade(&self) -> Option<Mutex<T>> {
         if let Some(inner) = self.inner.upgrade() {
             return Some(Mutex{inner})

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -140,9 +140,10 @@ struct Inner<T: ?Sized> {
     data: UnsafeCell<T>,
 }
 
-/// `MutexWeak` is non-owning reference to a mutex like [`Weak`] for [`Arc`].
+/// `MutexWeak` is a non-owning reference to a [`Mutex`].  `MutexWeak` is to 
+/// [`Mutex`] as [`std::sync::Weak`] is to [`std::sync::Arc`].
 /// 
-/// # Example
+/// # Examples
 /// ```
 /// # use futures_locks::{Mutex,MutexGuard};
 /// # fn main() {
@@ -152,14 +153,19 @@ struct Inner<T: ?Sized> {
 /// # }
 /// ```
 ///
-/// [`Weak`]: https://doc.rust-lang.org/std/sync/struct.Weak.html
-/// [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
+/// [`Mutex`]: struct.Mutex.html
+/// [`std::sync::Weak`]: https://doc.rust-lang.org/std/sync/struct.Weak.html
+/// [`std::sync::Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
 #[derive(Debug)]
 pub struct MutexWeak<T: ?Sized> {
     inner: sync::Weak<Inner<T>>,
 }
 
 impl<T: ?Sized> MutexWeak<T> {
+    /// Tries to upgrade the `MutexWeak` to `Mutex`. If the `Mutex` was dropped 
+    /// then the function return [`None`].
+    ///
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html
     pub fn upgrade(&self) -> Option<Mutex<T>> {
         if let Some(inner) = self.inner.upgrade() {
             return Some(Mutex{inner})
@@ -240,6 +246,9 @@ impl<T> Mutex<T> {
 }
 
 impl<T: ?Sized> Mutex<T> {
+    /// Create a [`MutexWeak`] reference to this `Mutex`.
+    ///
+    /// [`MutexWeak`]: struct.MutexWeak.html
     pub fn downgrade(this: &Mutex<T>) -> MutexWeak<T> {
         MutexWeak {inner: sync::Arc::<Inner<T>>::downgrade(&this.inner)}
     }

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -141,11 +141,11 @@ struct Inner<T: ?Sized> {
 }
 
 #[derive(Debug)]
-pub struct WeakMutex<T: ?Sized> {
+pub struct MutexWeak<T: ?Sized> {
     inner: sync::Weak<Inner<T>>,
 }
 
-impl<T: ?Sized> WeakMutex<T> {
+impl<T: ?Sized> MutexWeak<T> {
     pub fn upgrade(&self) -> Option<Mutex<T>> {
         if let Some(inner) = self.inner.upgrade() {
             return Some(Mutex{inner})
@@ -154,9 +154,9 @@ impl<T: ?Sized> WeakMutex<T> {
     }
 }
 
-impl<T: ?Sized> Clone for WeakMutex<T> {
-    fn clone(&self) -> WeakMutex<T> {
-        WeakMutex{inner: self.inner.clone()}
+impl<T: ?Sized> Clone for MutexWeak<T> {
+    fn clone(&self) -> MutexWeak<T> {
+        MutexWeak {inner: self.inner.clone()}
     }
 }
 
@@ -226,8 +226,8 @@ impl<T> Mutex<T> {
 }
 
 impl<T: ?Sized> Mutex<T> {
-    pub fn downgrade(this: &Mutex<T>) -> WeakMutex<T> {
-        WeakMutex {inner: sync::Arc::<Inner<T>>::downgrade(&this.inner)}
+    pub fn downgrade(this: &Mutex<T>) -> MutexWeak<T> {
+        MutexWeak {inner: sync::Arc::<Inner<T>>::downgrade(&this.inner)}
     }
 
     /// Returns a reference to the underlying data, if there are no other

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -10,6 +10,25 @@ use tokio::runtime;
 use tokio::runtime::current_thread;
 use futures_locks::*;
 
+// Create a MutexWeak and then upgrade it to Mutex
+#[test]
+fn mutex_weak_some() {
+    let mutex = Mutex::<u32>::new(0);
+    let mutex_weak = Mutex::downgrade(&mutex);
+
+    assert!(mutex_weak.upgrade().is_some())
+}
+
+// Create a MutexWeak and drop the mutex so that MutexWeak::upgrade return None
+#[test]
+fn mutext_weak_none() {
+    let mutex = Mutex::<u32>::new(0);
+    let mutex_weak = Mutex::downgrade(&mutex);
+
+    drop(mutex);
+
+    assert!(mutex_weak.upgrade().is_none())
+}
 
 // When a pending Mutex gets dropped, it should drain its channel and relinquish
 // ownership if a message was found.  If not, deadlocks may result.


### PR DESCRIPTION
I saw that you are using an `Arc` in your `Mutex`. So I implement the `WeakMutex` like the `Weak` struct in the `Arc`. To prevent that user wraps the `Mutex` again with an `Arc` to use the `Weak`.