### PR TITLE
Fix incorrect usage of semver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased] - ReleaseDate
 ### Added
+- Removed dependency on specific patch-version of futures.
+  ([#19](https://github.com/asomers/futures-locks/pull/19))
 - Added `MutexWeak`
   ([#17](https://github.com/asomers/futures-locks/pull/17)) 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ nightly-docs = []
 tokio = ["tokio-current-thread", "tokio-executor"]
 
 [dependencies]
-futures = "0.1.25"
+futures = "0.1"
 tokio-current-thread = { version = "0.1.4", optional = true }
 tokio-executor = { version = "0.1.5", optional = true }
 


### PR DESCRIPTION
This allows for using the newest bugfix version of futures (0.1.28) in crates and prevents dragging in multiple futures-versions.
You may want to that with other crates in the same way.
Pre 1.0 you should specify the sub-version `0.1`, afterwards the main-version `1`, as this will still guarantee backwards compatibility.
See [here](https://semver.org/) for further information.