### PR TITLE
Implement Mutex::ptr_eq()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Removed dependency on specific patch-version of futures.
   ([#19](https://github.com/asomers/futures-locks/pull/19))
 - Added `Mutex::ptr_eq()`
+  ([#20](https://github.com/asomers/futures-locks/pull/20))
 - Added `MutexWeak`
   ([#17](https://github.com/asomers/futures-locks/pull/17)) 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 - Removed dependency on specific patch-version of futures.
   ([#19](https://github.com/asomers/futures-locks/pull/19))
+- Added `Mutex::ptr_eq()`
 - Added `MutexWeak`
   ([#17](https://github.com/asomers/futures-locks/pull/17)) 
 

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -330,6 +330,11 @@ impl<T: ?Sized> Mutex<T> {
             mtx_data.owned = false;
         }
     }
+
+    /// Returns true if the two `Mutex` point to the same data else false.
+    pub fn ptr_eq(this: &Mutex<T>, other: &Mutex<T>) -> bool {
+        sync::Arc::ptr_eq(&this.inner, &other.inner)
+    }
 }
 
 impl<T: 'static + ?Sized> Mutex<T> {

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -21,7 +21,7 @@ fn mutex_weak_some() {
 
 // Create a MutexWeak and drop the mutex so that MutexWeak::upgrade return None
 #[test]
-fn mutext_weak_none() {
+fn mutex_weak_none() {
     let mutex = Mutex::<u32>::new(0);
     let mutex_weak = Mutex::downgrade(&mutex);
 

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -30,6 +30,24 @@ fn mutext_weak_none() {
     assert!(mutex_weak.upgrade().is_none())
 }
 
+// Compare Mutexes if it point to the same value
+#[test]
+fn mutex_eq_ptr_true() {
+    let mutex = Mutex::<u32>::new(0);
+    let mutex_other = mutex.clone();
+
+    assert!(Mutex::ptr_eq(&mutex, &mutex_other));
+}
+
+// Compare Mutexes if it point to the same value
+#[test]
+fn mutex_eq_ptr_false() {
+    let mutex = Mutex::<u32>::new(0);
+    let mutex_other = Mutex::<u32>::new(0);
+
+    assert!(!Mutex::ptr_eq(&mutex, &mutex_other));
+}
+
 // When a pending Mutex gets dropped, it should drain its channel and relinquish
 // ownership if a message was found.  If not, deadlocks may result.
 #[test]


### PR DESCRIPTION
I implement a method to compare if two `Mutex` point to the same value by using the `Arc::ptr_eq()` method.