### PR TITLE
Async await

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ test_task:
   name: cargo test 
   matrix:
     - container:
-       image: rust:1.32.0
+       image: rust:1.39.0
     - container:
        image: rust:latest
     - container:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - ReleaseNotes
+### Added
+### Changed
+- Updated to `std::future`.  `futures-locks` no longer works with
+  `futures-0.1`.  For `futures-0.1`-based applications, continue to use the 0.5
+  branch.  Most methods have similar interfaces.  However, the `IntoFuture`
+  trait no longer exists in the `std::future` world.  And `Future<T>` doesn't
+  implement `From<T>` (though I don't know why it couldn't).  So `Mutex::with`,
+  `RwLock::with_read`, and `RwLock::with_write` now take closures that return
+  `impl Future`, instead of `impl IntoFuture`.  Closure arguments that used to
+  return something like `Result<T, E>` should now return
+  `futures::future::ready<Result<T, E>>` instead.
+
+### Fixed
+### Removed
+
 ## [0.5.0] - 2019-11-03
 ### Added
 - Derived `Default` for `Mutex` and `RwLock`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,16 +29,16 @@ nightly-docs = []
 tokio = ["tokio-executor", "tokio_"]
 
 [dependencies]
-futures-preview = "=0.3.0-alpha.18"
-tokio-executor = { version = "0.2.0-alpha.5", optional = true, features = ["current-thread"] }
-tokio_ = { version = "0.2.0-alpha.5", optional = true, package = "tokio" }
+futures = "0.3.1"
+tokio-executor = { version = "0.2.0-alpha.6", optional = true, features = ["current-thread"] }
+tokio_ = { version = "0.2.0-alpha.6", optional = true, package = "tokio" }
 
 [dev-dependencies]
 # features, dependencies, dev-dependencies, and build-dependencies all share
 # the same namespace. To avoid a clash with the `tokio` feature, rename the
 # `tokio` dev-dependency. See https://github.com/rust-lang/cargo/issues/4866.
-tokio_ = { version = "0.2.0-alpha.5", package = "tokio" }
-tokio-test = { version = "0.2.0-alpha.5" }
+tokio_ = { version = "0.2.0-alpha.6", package = "tokio" }
+tokio-test = { version = "0.2.0-alpha.6" }
 
 [[test]]
 name = "functional"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,19 @@ features = ["tokio", "nightly-docs"]
 default = ["tokio"]
 # For building documentation only; no functional change to the library.
 nightly-docs = []
+# Enable methods that require a Tokio executor.
+tokio = ["tokio-executor", "tokio_"]
 
 [dependencies]
 futures-preview = "=0.3.0-alpha.18"
-tokio = { version = "0.2.0-alpha.5", optional = true }
+tokio-executor = { version = "0.2.0-alpha.5", optional = true, features = ["current-thread"] }
+tokio_ = { version = "0.2.0-alpha.5", optional = true, package = "tokio" }
 
 [dev-dependencies]
-tokio = { version = "0.2.0-alpha.5" }
+# features, dependencies, dev-dependencies, and build-dependencies all share
+# the same namespace. To avoid a clash with the `tokio` feature, rename the
+# `tokio` dev-dependency. See https://github.com/rust-lang/cargo/issues/4866.
+tokio_ = { version = "0.2.0-alpha.5", package = "tokio" }
 tokio-test = { version = "0.2.0-alpha.5" }
 
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,19 +25,14 @@ features = ["tokio", "nightly-docs"]
 default = ["tokio"]
 # For building documentation only; no functional change to the library.
 nightly-docs = []
-# Enable methods that require a Tokio executor.
-tokio = ["tokio-current-thread", "tokio-executor"]
 
 [dependencies]
-futures = "0.1.25"
-tokio-current-thread = { version = "0.1.4", optional = true }
-tokio-executor = { version = "0.1.5", optional = true }
+futures-preview = "=0.3.0-alpha.18"
+tokio = { version = "0.2.0-alpha.5", optional = true }
 
 [dev-dependencies]
-# features, dependencies, dev-dependencies, and build-dependencies all share
-# the same namespace. To avoid a clash with the `tokio` feature, rename the
-# `tokio` dev-dependency. See https://github.com/rust-lang/cargo/issues/4866.
-tokio_ = { version = "0.1.8", package = "tokio" }
+tokio = { version = "0.2.0-alpha.5" }
+tokio-test = { version = "0.2.0-alpha.5" }
 
 [[test]]
 name = "functional"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ a single task, not the entire reactor.
 ```toml
 # Cargo.toml
 [dependencies]
-futures-preview = "=0.3.0-alpha.18"
+futures = "0.3.1"
 futures-locks = "0.6"
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ a single task, not the entire reactor.
 ```toml
 # Cargo.toml
 [dependencies]
-futures = "0.1.25"
-futures-locks = "0.5"
+futures-preview = "=0.3.0-alpha.18"
+futures-locks = "0.6"
 ```
 
 # Usage
@@ -24,7 +24,7 @@ standard library.  But instead of blocking until ready, they return Futures
 which will become ready when the lock is acquired.  See the doc comments for
 individual examples.
 
-`futures-locks` requires Rust 1.32.0 or higher.
+`futures-locks` requires Rust 1.39.0 or higher.
 
 # License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,12 @@
 //!
 //! ```
 //! # use futures_locks::*;
-//! # use futures::executor::{Spawn, spawn};
-//! # use futures::Future;
+//! # use futures::executor::block_on;
+//! # use futures::{Future, FutureExt};
 //! # fn main() {
 //! let mtx = Mutex::<u32>::new(0);
 //! let fut = mtx.lock().map(|mut guard| { *guard += 5; });
-//! spawn(fut).wait_future();
+//! block_on(fut);
 //! assert_eq!(mtx.try_unwrap().unwrap(), 5);
 //! # }
 //! ```
@@ -34,11 +34,12 @@ pub use mutex::{Mutex, MutexFut, MutexGuard, MutexWeak};
 pub use rwlock::{RwLock, RwLockReadFut, RwLockWriteFut,
                  RwLockReadGuard, RwLockWriteGuard};
 
-use futures::sync::oneshot;
+use futures::channel::oneshot;
+use std::pin::Pin;
 
 /// Poll state of all Futures in this crate.
 enum FutState {
     New,
-    Pending(oneshot::Receiver<()>),
+    Pending(Pin<Box<oneshot::Receiver<()>>>),
     Acquired
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,11 +35,10 @@ pub use rwlock::{RwLock, RwLockReadFut, RwLockWriteFut,
                  RwLockReadGuard, RwLockWriteGuard};
 
 use futures::channel::oneshot;
-use std::pin::Pin;
 
 /// Poll state of all Futures in this crate.
 enum FutState {
     New,
-    Pending(Pin<Box<oneshot::Receiver<()>>>),
+    Pending(oneshot::Receiver<()>),
     Acquired
 }

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -135,7 +135,7 @@ fn lock_contested() {
     assert_ready!(fut1.poll());
 }
 
-//// A single Mutex is contested by tasks in multiple threads
+// A single Mutex is contested by tasks in multiple threads
 #[tokio::test]
 async fn lock_multithreaded() {
     let mutex = Mutex::<u32>::new(0);

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -1,12 +1,17 @@
 //vim: tw=80
 
-use futures::{Future, Stream, future, lazy, stream};
+use futures::{FutureExt, stream};
+use futures::future::join4;
+#[cfg(feature = "tokio")]
+use futures::future::ready;
+use futures::stream::StreamExt;
 #[cfg(feature = "tokio")]
 use std::rc::Rc;
 use tokio;
 #[cfg(feature = "tokio")]
-use tokio::runtime;
-use tokio::runtime::current_thread;
+use tokio::runtime::{self, current_thread};
+use tokio_test::task::spawn;
+use tokio_test::{assert_pending, assert_ready};
 use futures_locks::*;
 
 // Create a MutexWeak and then upgrade it to Mutex
@@ -50,25 +55,16 @@ fn mutex_eq_ptr_false() {
 // When a Mutex gets dropped after gaining ownership but before being polled, it
 // should drain its channel and relinquish ownership if a message was found.  If
 // not, deadlocks may result.
-#[test]
-fn drop_when_ready() {
+#[tokio::test]
+async fn drop_when_ready() {
     let mutex = Mutex::<u32>::new(0);
-    let mut rt = current_thread::Runtime::new().unwrap();
 
-    rt.block_on(lazy(|| {
-        let mut fut1 = mutex.lock();
-        let guard1 = fut1.poll();    // fut1 immediately gets ownership
-        assert!(guard1.as_ref().unwrap().is_ready());
-        let mut fut2 = mutex.lock();
-        assert!(!fut2.poll().unwrap().is_ready());
-        drop(guard1);                // ownership transfers to fut2
-        drop(fut1);
-        drop(fut2);                  // relinquish ownership
-        let mut fut3 = mutex.lock();
-        let guard3 = fut3.poll();    // fut3 immediately gets ownership
-        assert!(guard3.as_ref().unwrap().is_ready());
-        future::ok::<(), ()>(())
-    })).unwrap();
+    let guard1 = mutex.lock().await;
+    let fut2 = mutex.lock();
+    drop(guard1);                // ownership transfers to fut2
+    drop(fut2);                  // relinquish ownership
+    // The mutex should be available again
+    let _guard3 = mutex.lock().await;
 }
 
 // When a pending Mutex gets dropped after being polled() but before gaining
@@ -76,23 +72,22 @@ fn drop_when_ready() {
 #[test]
 fn drop_before_ready() {
     let mutex = Mutex::<u32>::new(0);
-    let mut rt = current_thread::Runtime::new().unwrap();
 
-    rt.block_on(lazy(|| {
-        let mut fut1 = mutex.lock();
-        let guard1 = fut1.poll();    // fut1 immediately gets ownership
-        assert!(guard1.as_ref().unwrap().is_ready());
-        let mut fut2 = mutex.lock();
-        assert!(!fut2.poll().unwrap().is_ready());
-        let mut fut3 = mutex.lock();
-        assert!(!fut3.poll().unwrap().is_ready());
-        drop(fut2);                  // drop before gaining ownership
-        drop(guard1);                // ownership transfers to fut3
-        drop(fut1);
-        let guard3 = fut3.poll();
-        assert!(guard3.as_ref().unwrap().is_ready());
-        future::ok::<(), ()>(())
-    })).unwrap();
+    let mut fut1 = spawn(mutex.lock());
+    let guard1 = assert_ready!(fut1.poll()); // fut1 immediately gets ownership
+
+    let mut fut2 = spawn(mutex.lock());
+    assert_pending!(fut2.poll());            // fut2 is blocked
+
+    let mut fut3 = spawn(mutex.lock());
+    assert_pending!(fut3.poll());            // fut3 is blocked, too
+
+    drop(fut2);                  // drop before gaining ownership
+    drop(guard1);                // ownership transfers to fut3
+    drop(fut1);
+
+    assert!(fut3.is_woken());
+    assert_ready!(fut3.poll());
 }
 
 // Mutably dereference a uniquely owned Mutex
@@ -112,16 +107,14 @@ fn get_mut_cloned() {
 }
 
 // Acquire an uncontested Mutex.  poll immediately returns Async::Ready
-#[test]
-fn lock_uncontested() {
+// #[test]
+#[tokio::test]
+async fn lock_uncontested() {
     let mutex = Mutex::<u32>::new(0);
-    let mut rt = current_thread::Runtime::new().unwrap();
 
-    let result = rt.block_on(lazy(|| {
-        mutex.lock().map(|guard| {
-            *guard + 5
-        })
-    })).unwrap();
+    let guard = mutex.lock().await;
+    let result = *guard + 5;
+    drop(guard);
     assert_eq!(result, 5);
 }
 
@@ -130,64 +123,52 @@ fn lock_uncontested() {
 #[test]
 fn lock_contested() {
     let mutex = Mutex::<u32>::new(0);
-    let mut rt = current_thread::Runtime::new().unwrap();
 
-    rt.block_on(lazy(|| {
-        let mut fut0 = mutex.lock();
-        let guard0 = fut0.poll();    // fut0 immediately gets ownership
-        assert!(guard0.as_ref().unwrap().is_ready());
+    let mut fut0 = spawn(mutex.lock());
+    let guard0 = assert_ready!(fut0.poll()); // fut0 immediately gets ownership
 
-        let mut fut1 = mutex.lock();
-        assert!(!fut1.poll().unwrap().is_ready());  // fut1 is blocked
+    let mut fut1 = spawn(mutex.lock());
+    assert_pending!(fut1.poll());            // fut1 is blocked
 
-        drop(guard0);               // Ownership transfers to fut1
-        let guard1 = fut1.poll();
-        assert!(guard1.as_ref().unwrap().is_ready());
-        future::ok::<(), ()>(())
-    })).unwrap();
+    drop(guard0);                            // Ownership transfers to fut1
+    assert!(fut1.is_woken());
+    assert_ready!(fut1.poll());
 }
 
-// A single Mutex is contested by tasks in multiple threads
-#[test]
-fn lock_multithreaded() {
+//// A single Mutex is contested by tasks in multiple threads
+#[tokio::test]
+async fn lock_multithreaded() {
     let mutex = Mutex::<u32>::new(0);
     let mtx_clone0 = mutex.clone();
     let mtx_clone1 = mutex.clone();
     let mtx_clone2 = mutex.clone();
     let mtx_clone3 = mutex.clone();
 
-    let parent = lazy(move || {
-        tokio::spawn(stream::iter_ok::<_, ()>(0..1000).for_each(move |_| {
-            mtx_clone0.lock().map(|mut guard| { *guard += 2 })
-        }));
-        tokio::spawn(stream::iter_ok::<_, ()>(0..1000).for_each(move |_| {
-            mtx_clone1.lock().map(|mut guard| { *guard += 3 })
-        }));
-        tokio::spawn(stream::iter_ok::<_, ()>(0..1000).for_each(move |_| {
-            mtx_clone2.lock().map(|mut guard| { *guard += 5 })
-        }));
-        tokio::spawn(stream::iter_ok::<_, ()>(0..1000).for_each(move |_| {
-            mtx_clone3.lock().map(|mut guard| { *guard += 7 })
-        }));
-        future::ok::<(), ()>(())
+    let task0 = stream::iter(0..1000).for_each(move |_| {
+        mtx_clone0.lock().map(|mut guard| { *guard += 2 })
+    });
+    let task1 = stream::iter(0..1000).for_each(move |_| {
+        mtx_clone1.lock().map(|mut guard| { *guard += 3 })
+    });
+    let task2 = stream::iter(0..1000).for_each(move |_| {
+        mtx_clone2.lock().map(|mut guard| { *guard += 5 })
+    });
+    let task3 = stream::iter(0..1000).for_each(move |_| {
+        mtx_clone3.lock().map(|mut guard| { *guard += 7 })
     });
 
-    tokio::run(parent);
+    join4(task0, task1, task2, task3).await;
     assert_eq!(mutex.try_unwrap().expect("try_unwrap"), 17_000);
 }
 
 // Mutexes should be acquired in the order that their Futures are waited upon.
-#[test]
-fn lock_order() {
+#[tokio::test]
+async fn lock_order() {
     let mutex = Mutex::<Vec<u32>>::new(vec![]);
     let fut2 = mutex.lock().map(|mut guard| guard.push(2));
     let fut1 = mutex.lock().map(|mut guard| guard.push(1));
-    let mut rt = current_thread::Runtime::new().unwrap();
 
-    let r = rt.block_on(lazy(|| {
-        fut1.and_then(|_| fut2)
-    }));
-    assert!(r.is_ok());
+    fut1.then(|_| fut2).await;
     assert_eq!(mutex.try_unwrap().unwrap(), vec![1, 2]);
 }
 
@@ -216,20 +197,21 @@ fn try_unwrap_multiply_referenced() {
     assert!(mtx.try_unwrap().is_err());
 }
 
+// Returning errors is simpler than in futures-locks 0.5: just return a Result
 #[cfg(feature = "tokio")]
 #[test]
 fn with_err() {
     let mtx = Mutex::<i32>::new(-5);
     let mut rt = current_thread::Runtime::new().unwrap();
-    let r = rt.block_on(lazy(|| {
+    let r = rt.block_on(async {
         mtx.with(|guard| {
             if *guard > 0 {
-                Ok(*guard)
+                ready(Ok(*guard))
             } else {
-                Err("Whoops!")
+                ready(Err("Whoops!"))
             }
-        }).unwrap()
-    }));
+        }).await
+    });
     assert_eq!(r, Err("Whoops!"));
 }
 
@@ -238,12 +220,12 @@ fn with_err() {
 fn with_ok() {
     let mtx = Mutex::<i32>::new(5);
     let mut rt = current_thread::Runtime::new().unwrap();
-    let r = rt.block_on(lazy(move || {
+    let r = rt.block_on(async {
         mtx.with(|guard| {
-            Ok(*guard) as Result<i32, ()>
-        }).unwrap()
-    }));
-    assert_eq!(r, Ok(5));
+            ready(*guard)
+        }).await
+    });
+    assert_eq!(r, 5);
 }
 
 // Mutex::with should work with multithreaded Runtimes as well as
@@ -253,13 +235,13 @@ fn with_ok() {
 #[test]
 fn with_threadpool() {
     let mtx = Mutex::<i32>::new(5);
-    let mut rt = runtime::Runtime::new().unwrap();
-    let r = rt.block_on(lazy(move || {
+    let rt = runtime::Runtime::new().unwrap();
+    let r = rt.block_on(async {
         mtx.with(|guard| {
-            Ok(*guard) as Result<i32, ()>
-        }).unwrap()
-    }));
-    assert_eq!(r, Ok(5));
+            ready(*guard)
+        }).await
+    });
+    assert_eq!(r, 5);
 }
 
 #[cfg(feature = "tokio")]
@@ -268,10 +250,10 @@ fn with_local_ok() {
     // Note: Rc is not Send
     let mtx = Mutex::<Rc<i32>>::new(Rc::new(5));
     let mut rt = current_thread::Runtime::new().unwrap();
-    let r = rt.block_on(lazy(move || {
+    let r = rt.block_on(async {
         mtx.with_local(|guard| {
-            Ok(**guard) as Result<i32, ()>
-        }).unwrap()
-    }));
-    assert_eq!(r, Ok(5));
+            ready(**guard)
+        }).await
+    });
+    assert_eq!(r, 5);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,6 @@
 //vim: tw=80
 
+extern crate tokio_ as tokio;
+
 mod mutex;
 mod rwlock;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,4 @@
 //vim: tw=80
 
-extern crate tokio_ as tokio;
-
 mod mutex;
 mod rwlock;


### PR DESCRIPTION
Convert to the world of async/await

This replaces futures-0.1 with std::future.  It is a backwards-incompatible change!  The MSRV is now 1.39.0.  See CHANGELOG for more information.

