### PR TITLE
Don't use Tokio 0.2.0; stick with 0.2.0-alpha.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,15 +30,15 @@ tokio = ["tokio-executor", "tokio_"]
 
 [dependencies]
 futures = "0.3.1"
-tokio-executor = { version = "0.2.0-alpha.6", optional = true, features = ["current-thread"] }
-tokio_ = { version = "0.2.0-alpha.6", optional = true, package = "tokio" }
+tokio-executor = { version = "=0.2.0-alpha.6", optional = true, features = ["current-thread"] }
+tokio_ = { version = "=0.2.0-alpha.6", optional = true, package = "tokio" }
 
 [dev-dependencies]
 # features, dependencies, dev-dependencies, and build-dependencies all share
 # the same namespace. To avoid a clash with the `tokio` feature, rename the
 # `tokio` dev-dependency. See https://github.com/rust-lang/cargo/issues/4866.
-tokio_ = { version = "0.2.0-alpha.6", package = "tokio" }
-tokio-test = { version = "0.2.0-alpha.6" }
+tokio_ = { version = "=0.2.0-alpha.6", package = "tokio" }
+tokio-test = { version = "=0.2.0-alpha.6" }
 
 [[test]]
 name = "functional"


### PR DESCRIPTION
Tokio 0.2.0 removes runtime::current_thread but doesn't provide a fully
functional replacement.

See https://github.com/tokio-rs/tokio/issues/1906