### PR TITLE
Depend on tokio's "rt-core" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,21 +22,20 @@ autotests = false
 features = ["tokio", "nightly-docs"]
 
 [features]
+# Enable methods that require a Tokio runtime.
 default = ["tokio"]
 # For building documentation only; no functional change to the library.
 nightly-docs = []
-# Enable methods that require a Tokio runtime.
-tokio = ["tokio_"]
 
 [dependencies]
 futures = "0.3.1"
-tokio_ = { version = "0.2.7", features = ["rt-util"], optional = true, package = "tokio" }
+tokio = { version = "0.2.7", features = ["rt-core", "rt-util"], optional = true }
 
 [dev-dependencies]
 # features, dependencies, dev-dependencies, and build-dependencies all share
 # the same namespace. To avoid a clash with the `tokio` feature, rename the
 # `tokio` dev-dependency. See https://github.com/rust-lang/cargo/issues/4866.
-tokio_ = { version = "0.2.7", features = ["sync", "macros", "rt-threaded"], package = "tokio" }
+tokio = { version = "0.2.7", features = ["sync", "macros", "rt-threaded"] }
 tokio-test = { version = "0.2.0" }
 
 [[test]]

--- a/benches/mutex.rs
+++ b/benches/mutex.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 
 extern crate test;
-extern crate tokio_ as tokio;
+extern crate tokio as tokio;
 
 use futures::{
     FutureExt,

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -15,7 +15,7 @@ use std::{
 };
 use super::FutState;
 #[cfg(feature = "tokio")] use futures::FutureExt;
-#[cfg(feature = "tokio")] use tokio_::task;
+#[cfg(feature = "tokio")] use tokio::task;
 
 /// An RAII mutex guard, much like `std::sync::MutexGuard`.  The wrapped data
 /// can be accessed via its `Deref` and `DerefMut` implementations.
@@ -353,7 +353,7 @@ impl<T: 'static + ?Sized> Mutex<T> {
     /// ```
     /// # use futures_locks::*;
     /// # use futures::{Future, future::ready};
-    /// # use tokio_::runtime::Runtime;
+    /// # use tokio::runtime::Runtime;
     /// # fn main() {
     /// let mtx = Mutex::<u32>::new(0);
     /// let mut rt = Runtime::new().unwrap();
@@ -376,7 +376,7 @@ impl<T: 'static + ?Sized> Mutex<T> {
               T: Send
     {
         let (tx, rx) = oneshot::channel::<R>();
-        tokio_::spawn(self.lock()
+        tokio::spawn(self.lock()
             .then(move |data| {
                 f(data)
                 .map(move |result| {
@@ -400,7 +400,7 @@ impl<T: 'static + ?Sized> Mutex<T> {
     /// # use futures_locks::*;
     /// # use futures::{Future, future::ready};
     /// # use std::rc::Rc;
-    /// # use tokio_::runtime::Runtime;
+    /// # use tokio::runtime::Runtime;
     /// # fn main() {
     /// // Note: Rc is not `Send`
     /// let mtx = Mutex::<Rc<u32>>::new(Rc::new(0));

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -15,7 +15,7 @@ use std::{
 };
 use super::FutState;
 #[cfg(feature = "tokio")] use futures::FutureExt;
-#[cfg(feature = "tokio")] use tokio_::task;
+#[cfg(feature = "tokio")] use tokio::task;
 
 /// An RAII guard, much like `std::sync::RwLockReadGuard`.  The wrapped data can
 /// be accessed via its `Deref` implementation.
@@ -492,7 +492,7 @@ impl<T: 'static + ?Sized> RwLock<T> {
     /// ```
     /// # use futures_locks::*;
     /// # use futures::{Future, future::ready};
-    /// # use tokio_::runtime::Runtime;
+    /// # use tokio::runtime::Runtime;
     /// # fn main() {
     /// let rwlock = RwLock::<u32>::new(5);
     /// let mut rt = Runtime::new().unwrap();
@@ -514,7 +514,7 @@ impl<T: 'static + ?Sized> RwLock<T> {
               T: Send
     {
         let (tx, rx) = oneshot::channel::<R>();
-        tokio_::spawn(self.read()
+        tokio::spawn(self.read()
             .then(move |data| {
                 f(data)
                 .map(move |result| {
@@ -539,7 +539,7 @@ impl<T: 'static + ?Sized> RwLock<T> {
     /// # use futures_locks::*;
     /// # use futures::{Future, future::ready};
     /// # use std::rc::Rc;
-    /// # use tokio_::runtime::Runtime;
+    /// # use tokio::runtime::Runtime;
     /// # fn main() {
     /// // Note: Rc is not `Send`
     /// let rwlock = RwLock::<Rc<u32>>::new(Rc::new(5));
@@ -595,7 +595,7 @@ impl<T: 'static + ?Sized> RwLock<T> {
     /// ```
     /// # use futures::{Future, future::ready};
     /// # use futures_locks::*;
-    /// # use tokio_::runtime::Runtime;
+    /// # use tokio::runtime::Runtime;
     /// # fn main() {
     /// let rwlock = RwLock::<u32>::new(0);
     /// let mut rt = Runtime::new().unwrap();
@@ -618,7 +618,7 @@ impl<T: 'static + ?Sized> RwLock<T> {
               T: Send
     {
         let (tx, rx) = oneshot::channel::<R>();
-        tokio_::spawn(self.write()
+        tokio::spawn(self.write()
             .then(move |data| {
                 f(data)
                 .map(move |result| {
@@ -643,7 +643,7 @@ impl<T: 'static + ?Sized> RwLock<T> {
     /// # use futures::{Future, future::ready};
     /// # use futures_locks::*;
     /// # use std::rc::Rc;
-    /// # use tokio_::runtime::Runtime;
+    /// # use tokio::runtime::Runtime;
     /// # fn main() {
     /// // Note: Rc is not `Send`
     /// let rwlock = RwLock::<Rc<u32>>::new(Rc::new(0));

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 #[cfg(feature = "tokio")]
 use std::rc::Rc;
 use tokio::{self, sync::Barrier};
+#[cfg(feature = "tokio")]
 use tokio::runtime;
 use tokio_test::task::spawn;
 use tokio_test::{assert_pending, assert_ready};

--- a/tests/rwlock.rs
+++ b/tests/rwlock.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 #[cfg(feature = "tokio")]
 use std::rc::Rc;
 use tokio::{self, sync::Barrier};
+#[cfg(feature = "tokio")]
 use tokio::runtime;
 use tokio_test::{
     assert_pending,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,6 @@
 //vim: tw=80
 
-extern crate tokio_ as tokio;
+extern crate tokio as tokio;
 
 mod mutex;
 mod rwlock;


### PR DESCRIPTION
I don't know why, but dependent crates can't build futures-locks even
though futures-locks's tests build just fine.  "rt-core" definitely
should be required.

Also, there is no longer any need to rename tokio to tokio_.