### PR TITLE
Return a dedicated error type from the try_ methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - ReleaseDate
+### Added
+### Changed
+- `Mutex::try_lock`, `RwLock::try_read`, and `RwLock::try_write`, now return a
+  dedicated error type instead of `()`, and it implements `std::error::Error`.
+  ([#41](https://github.com/asomers/futures-locks/pull/41))
+### Fixed
+### Removed
+
 ## [0.6.0] - ReleaseNotes
 ### Added
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub use rwlock::{RwLock, RwLockReadFut, RwLockWriteFut,
                  RwLockReadGuard, RwLockWriteGuard};
 
 use futures::channel::oneshot;
+use std::{error, fmt};
 
 /// Poll state of all Futures in this crate.
 enum FutState {
@@ -42,3 +43,16 @@ enum FutState {
     Pending(oneshot::Receiver<()>),
     Acquired
 }
+
+/// The lock could not be acquired at this time because the operation would
+/// otherwise block.
+#[derive(Clone, Copy, Debug)]
+pub struct TryLockError;
+
+impl fmt::Display for TryLockError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "try_lock failed because the operation would block")
+    }
+}
+
+impl error::Error for TryLockError {}

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -13,7 +13,7 @@ use std::{
     pin::Pin,
     sync
 };
-use super::FutState;
+use super::{FutState, TryLockError};
 #[cfg(feature = "tokio")] use futures::FutureExt;
 #[cfg(feature = "tokio")] use tokio::task;
 
@@ -300,14 +300,14 @@ impl<T: ?Sized> Mutex<T> {
     /// let mut mtx = Mutex::<u32>::new(0);
     /// match mtx.try_lock() {
     ///     Ok(mut guard) => *guard += 5,
-    ///     Err(()) => println!("Better luck next time!")
+    ///     Err(_) => println!("Better luck next time!")
     /// };
     /// # }
     /// ```
-    pub fn try_lock(&self) -> Result<MutexGuard<T>, ()> {
+    pub fn try_lock(&self) -> Result<MutexGuard<T>, TryLockError> {
         let mut mtx_data = self.inner.mutex.lock().expect("sync::Mutex::lock");
         if mtx_data.owned {
-            Err(())
+            Err(TryLockError)
         } else {
             mtx_data.owned = true;
             Ok(MutexGuard{mutex: self.clone()})


### PR DESCRIPTION
Previously they returned Result<_, ()>, because there was only one
possible error.  Now they return a dedicated error type that implements
std::error::Error.