### PR TITLE
Fix unsoundness in RwLock Sync impl

### DIFF
--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -645,7 +645,7 @@ impl<T: 'static + ?Sized> RwLock<T> {
 }
 
 unsafe impl<T: ?Sized + Send> Send for RwLock<T> {}
-unsafe impl<T: ?Sized + Send> Sync for RwLock<T> {}
+unsafe impl<T: ?Sized + Send + Sync> Sync for RwLock<T> {}
 
 // LCOV_EXCL_START
 #[cfg(test)]


### PR DESCRIPTION
Previously, the RwLock could be used to obtain references to the same non-Sync type in different threads, which is undefined behavior.

Fixes #37.