### PR TITLE
Explicitly install clippy during CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,6 +33,7 @@ test_task:
     - fi
   clippy_script:
     - if rustc --version | grep -q nightly; then
+    -   rustup component add clippy
     -   cargo clippy --all-features --all-targets
     - fi
   audit_script:


### PR DESCRIPTION
It used to be included in the rust:latest container, but apparently no longer is.