### PR TITLE
Clippy cleanup: unused_must_use

### DIFF
--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -440,13 +440,6 @@ unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
 mod t {
     use super::*;
 
-    /// Pet Kcov
-    #[test]
-    fn debug() {
-        let m = Mutex::<u32>::new(0);
-        format!("{:?}", &m);
-    }
-
     #[test]
     fn test_default() {
         let m = Mutex::default();

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -666,13 +666,6 @@ unsafe impl<T: ?Sized + Send + Sync> Sync for RwLock<T> {}
 mod t {
     use super::*;
 
-    /// Pet Kcov
-    #[test]
-    fn debug() {
-        let m = RwLock::<u32>::new(0);
-        format!("{:?}", &m);
-    }
-
     #[test]
     fn test_default() {
         let lock = RwLock::default();


### PR DESCRIPTION
Delete the relevant code.  It's no longer even useful with the latest rustc, which knows not to care whether derived Debug impls are covered.