### PR TITLE
Switch CI's minver check to use -Zminimal-versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,7 +43,7 @@ test_task:
     - fi
   minver_script:
     - if rustc --version | grep -q nightly; then
-    -   cargo update -Zdirect-minimal-versions
+    -   cargo update -Zminimal-versions
     -   cargo check --all-targets
     - fi
   before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ test_task:
     RUSTDOCFLAGS: -D warnings
   matrix:
     - container:
-       image: rust:1.49.0
+       image: rust:1.65.0
     - container:
        image: rust:latest
     - container:
@@ -12,7 +12,7 @@ test_task:
   cargo_cache:
     folder: $CARGO_HOME/registry
   build_script:
-    - if rustc --version | grep -q 1.49.0; then
+    - if rustc --version | grep -q 1.65.0; then
     -   cp Cargo.lock.msrv Cargo.lock
     - fi
     - if rustc --version | grep -q nightly; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+### Changed
+
+- MSRV has been raised to 1.65.0, due to the futures-util crate yanking all
+  versions compatible with older compilers.
+  ([#61](https://github.com/asomers/futures-locks/pull/61))
+
 ## [0.7.1] - 2022-12-07
 
 - The published package on crates.io now includes functional tests.  No

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { version = "1.2", features = ["rt"], optional = true }
 [dev-dependencies]
 futures = "0.3.11"
 tokio = { version = "1.2", features = ["sync", "macros", "rt-multi-thread"] }
-tokio-test = { version = "0.4.2" }
+tokio-test = { version = "0.4.3" }
 
 [[test]]
 name = "functional"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["asynchronous"]
 documentation = "https://docs.rs/futures-locks"
 autotests = false
 include = ["src/**/*", "tests/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 features = ["tokio"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ standard library.  But instead of blocking until ready, they return Futures
 which will become ready when the lock is acquired.  See the doc comments for
 individual examples.
 
-`futures-locks` requires Rust 1.49.0 or higher.
+`futures-locks` requires Rust 1.65.0 or higher.
 
 # License
 


### PR DESCRIPTION
Using -Zdirect-minimal-versions now fails due to an indirect dependency (futures-util) now depending on a direct dependency (futures-channel). -Zdirect-minimal-versions brings in the latest version of every indirect dependency, which conflicts with bringing in the oldest version of futures-channel.

A complicating factor is that every version of futures-util from 0.3.0 to 0.3.30, inclusive, has been yanked.  Unwisely, IMHO.